### PR TITLE
회원가입/로그인 기능 구현

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,39 @@
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
         </dependency>
+
+        <!-- Security -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
+        </dependency>
+
+        <!-- JWT -->
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-api</artifactId>
+            <version>0.11.2</version>
+            <scope>compile</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-impl</artifactId>
+            <version>0.11.2</version>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-jackson</artifactId>
+            <version>0.11.2</version>
+            <scope>runtime</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/me/seowoo/market/config/JwtSecurityConfig.java
+++ b/src/main/java/me/seowoo/market/config/JwtSecurityConfig.java
@@ -1,0 +1,23 @@
+package me.seowoo.market.config;
+
+import lombok.RequiredArgsConstructor;
+import me.seowoo.market.jwt.JwtFilter;
+import me.seowoo.market.jwt.TokenProvider;
+import org.springframework.security.config.annotation.SecurityConfigurerAdapter;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.DefaultSecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+// 직접 만든 TokenProvider와 JwtFilter를 SecurityConfig에 적용할 때 사용
+@RequiredArgsConstructor
+public class JwtSecurityConfig extends SecurityConfigurerAdapter<DefaultSecurityFilterChain, HttpSecurity> {
+
+    private final TokenProvider tokenProvider;
+
+    // TokenProvider를 주입 받아서 JwtFilter를 통해 Security 로직에 필터를 등록
+    @Override
+    public void configure(HttpSecurity http) {
+        JwtFilter customFilter = new JwtFilter(tokenProvider);
+        http.addFilterBefore(customFilter, UsernamePasswordAuthenticationFilter.class);
+    }
+}

--- a/src/main/java/me/seowoo/market/config/SecurityConfig.java
+++ b/src/main/java/me/seowoo/market/config/SecurityConfig.java
@@ -1,0 +1,68 @@
+package me.seowoo.market.config;
+
+
+import lombok.RequiredArgsConstructor;
+import me.seowoo.market.jwt.JwtAccessDeniedHandler;
+import me.seowoo.market.jwt.JwtAuthenticationEntryPoint;
+import me.seowoo.market.jwt.TokenProvider;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.builders.WebSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig extends WebSecurityConfigurerAdapter {
+
+    private final TokenProvider tokenProvider;
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+    private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    // 인증이 필요 없는 리소스 설정
+    @Override
+    public void configure(WebSecurity web) {
+        web.ignoring()
+                .antMatchers("/h2-console/**", "/favicon.ico");
+    }
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        // CSRF 설정 Disable
+        http.csrf().disable()
+
+                // Exception Handling
+                .exceptionHandling()
+                .authenticationEntryPoint(jwtAuthenticationEntryPoint)
+                .accessDeniedHandler(jwtAccessDeniedHandler)
+
+                // h2-console을 위한 설정 추가
+                .and()
+                .headers()
+                .frameOptions()
+                .sameOrigin()
+
+                // 시큐리티는 기본적으로 세션을 사용하는데, 세션을 사용하지 않을 것이므로 Stateless로 설정
+                .and()
+                .sessionManagement()
+                .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+
+                // 회원가입, 로그인 API 등 토큰이 없는 상태에서 들어오는 요청에 대해 permitAll 설정
+                .and()
+                .authorizeRequests()
+                .antMatchers("/auth/**").permitAll()
+                .anyRequest().authenticated()
+
+                // JwtFilter를 addFilterBefore로 등록했던 JwtSecurityConfig 클래스 적용
+                .and()
+                .apply(new JwtSecurityConfig(tokenProvider));
+    }
+}

--- a/src/main/java/me/seowoo/market/controller/AuthController.java
+++ b/src/main/java/me/seowoo/market/controller/AuthController.java
@@ -1,0 +1,30 @@
+package me.seowoo.market.controller;
+
+import lombok.RequiredArgsConstructor;
+import me.seowoo.market.dto.MemberRequestDto;
+import me.seowoo.market.dto.MemberResponseDto;
+import me.seowoo.market.dto.TokenDto;
+import me.seowoo.market.service.AuthService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/signup")
+    public ResponseEntity<MemberResponseDto> signup(@RequestBody MemberRequestDto memberRequestDto) {
+        return ResponseEntity.ok(authService.signup(memberRequestDto));
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<TokenDto> login(@RequestBody MemberRequestDto memberRequestDto) {
+        return ResponseEntity.ok(authService.login(memberRequestDto));
+    }
+}

--- a/src/main/java/me/seowoo/market/controller/MemberController.java
+++ b/src/main/java/me/seowoo/market/controller/MemberController.java
@@ -1,0 +1,28 @@
+package me.seowoo.market.controller;
+
+import lombok.RequiredArgsConstructor;
+import me.seowoo.market.dto.MemberResponseDto;
+import me.seowoo.market.service.MemberService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/member")
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @GetMapping("/me")
+    public ResponseEntity<MemberResponseDto> getMyMemberInfo() {
+        return ResponseEntity.ok(memberService.getMyInfo());
+    }
+
+    @GetMapping("/{email}")
+    public ResponseEntity<MemberResponseDto> getMemberInfo(@PathVariable String email) {
+        return ResponseEntity.ok(memberService.getMemberInfo(email));
+    }
+}

--- a/src/main/java/me/seowoo/market/dto/MemberRequestDto.java
+++ b/src/main/java/me/seowoo/market/dto/MemberRequestDto.java
@@ -1,0 +1,31 @@
+package me.seowoo.market.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import me.seowoo.market.entity.Authority;
+import me.seowoo.market.entity.Member;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class MemberRequestDto {
+
+    private String email;
+
+    private String password;
+
+    public Member toMember(PasswordEncoder passwordEncoder) {
+        return Member.builder()
+                .email(email)
+                .password(passwordEncoder.encode(password))
+                .authority(Authority.ROLE_USER)
+                .build();
+    }
+
+    public UsernamePasswordAuthenticationToken toAuthentication() {
+        return new UsernamePasswordAuthenticationToken(email, password);
+    }
+}

--- a/src/main/java/me/seowoo/market/dto/MemberResponseDto.java
+++ b/src/main/java/me/seowoo/market/dto/MemberResponseDto.java
@@ -1,0 +1,18 @@
+package me.seowoo.market.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import me.seowoo.market.entity.Member;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class MemberResponseDto {
+
+    private String email;
+
+    public static MemberResponseDto of(Member member) {
+        return new MemberResponseDto(member.getEmail());
+    }
+}

--- a/src/main/java/me/seowoo/market/dto/TokenDto.java
+++ b/src/main/java/me/seowoo/market/dto/TokenDto.java
@@ -1,0 +1,19 @@
+package me.seowoo.market.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class TokenDto {
+
+    private String grantType;
+
+    private String accessToken;
+
+    private Long accessTokenExpiresIn;
+}

--- a/src/main/java/me/seowoo/market/entity/Authority.java
+++ b/src/main/java/me/seowoo/market/entity/Authority.java
@@ -1,0 +1,5 @@
+package me.seowoo.market.entity;
+
+public enum Authority {
+    ROLE_USER, ROLE_ADMIN
+}

--- a/src/main/java/me/seowoo/market/entity/Member.java
+++ b/src/main/java/me/seowoo/market/entity/Member.java
@@ -1,0 +1,34 @@
+package me.seowoo.market.entity;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+
+@Getter
+@NoArgsConstructor
+@Table(name = "member")
+@Entity
+public class Member {
+
+    @Id
+    @Column(name = "member_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String email;
+
+    private String password;
+
+    @Enumerated(EnumType.STRING)
+    private Authority authority;
+
+    @Builder
+    public Member(String email, String password, Authority authority) {
+        this.email = email;
+        this.password = password;
+        this.authority = authority;
+    }
+}

--- a/src/main/java/me/seowoo/market/jwt/JwtAccessDeniedHandler.java
+++ b/src/main/java/me/seowoo/market/jwt/JwtAccessDeniedHandler.java
@@ -1,0 +1,20 @@
+package me.seowoo.market.jwt;
+
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Component
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        // 필요한 권한 없이 접근을 시도할 때 403
+        response.sendError(HttpServletResponse.SC_FORBIDDEN);
+    }
+}

--- a/src/main/java/me/seowoo/market/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/me/seowoo/market/jwt/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,19 @@
+package me.seowoo.market.jwt;
+
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
+        // 유효한 자격 증명을 제공하지 않고 접근을 시도할 때 401
+        response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+    }
+}

--- a/src/main/java/me/seowoo/market/jwt/JwtFilter.java
+++ b/src/main/java/me/seowoo/market/jwt/JwtFilter.java
@@ -1,0 +1,48 @@
+package me.seowoo.market.jwt;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class JwtFilter extends OncePerRequestFilter {
+
+    public static final String AUTHORIZATION_HEADER = "Authorization";
+    public static final String BEARER_PREFIX = "Bearer ";
+
+    private final TokenProvider tokenProvider;
+
+    // 실제 필터링 로직 수행
+    // JWT 인증 정보를 현재 스레드의 SecurityContext에 저장
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws IOException, ServletException {
+        // 1. Request Header에서 토큰 꺼냄
+        String jwt = resolveToken(request);
+
+        // 2. validateToken으로 토큰 유효성 검사
+        // 정상 토큰이면 해당 토큰으로 Authentication을 가져와서 SecurityContext에 저장
+        if (StringUtils.hasText(jwt) && tokenProvider.validateToken(jwt)) {
+            Authentication authentication = tokenProvider.getAuthentication(jwt);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    // Request Header에서 토큰 정보 꺼내오기
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+}

--- a/src/main/java/me/seowoo/market/jwt/TokenProvider.java
+++ b/src/main/java/me/seowoo/market/jwt/TokenProvider.java
@@ -1,0 +1,105 @@
+package me.seowoo.market.jwt;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
+import me.seowoo.market.dto.TokenDto;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Component
+public class TokenProvider {
+
+    private static final String AUTHORITIES_KEY = "auth";
+    private static final String BEARER_TYPE = "bearer";
+    private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 30;    // 30분
+
+    private final Key key;
+
+    public TokenProvider(@Value("${jwt.secret}") String secretKey) {
+        byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    public TokenDto generateTokenDto(Authentication authentication) {
+        // 권한들 가져오기
+        String authorities = authentication.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.joining(","));
+
+        long now = (new Date()).getTime();
+
+        // Access Token 생성
+        Date accessTokenExpiresIn = new Date(now + ACCESS_TOKEN_EXPIRE_TIME);
+        String accessToken = Jwts.builder()
+                .setSubject(authentication.getName())       // payload "sub": "name"
+                .claim(AUTHORITIES_KEY, authorities)        // payload "auth": "ROLE_USER"
+                .setExpiration(accessTokenExpiresIn)        // payload "exp": 1516239022 (예시)
+                .signWith(key, SignatureAlgorithm.HS512)    // header "alg": "HS512"
+                .compact();
+
+        return TokenDto.builder()
+                .grantType(BEARER_TYPE)
+                .accessToken(accessToken)
+                .accessTokenExpiresIn(accessTokenExpiresIn.getTime())
+                .build();
+    }
+
+    public Authentication getAuthentication(String accessToken) {
+        // 토큰 복호화
+        Claims claims = parseClaims(accessToken);
+
+        if (claims.get(AUTHORITIES_KEY) == null) {
+            throw new RuntimeException("권한 정보가 없는 토큰입니다.");
+        }
+
+        // 클레임에서 권한 정보 가져오기
+        Collection<? extends GrantedAuthority> authorities =
+                Arrays.stream(claims.get(AUTHORITIES_KEY).toString().split(","))
+                        .map(SimpleGrantedAuthority::new)
+                        .collect(Collectors.toList());
+
+        // UserDetails 객체를 생성해서 Authentication 반환
+        UserDetails principal = new User(claims.getSubject(), "", authorities);
+
+        return new UsernamePasswordAuthenticationToken(principal, "", authorities);
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+            return true;
+        } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
+            log.info("잘못된 JWT 서명입니다.");
+        } catch (ExpiredJwtException e) {
+            log.info("만료된 JWT 토큰입니다.");
+        } catch (UnsupportedJwtException e) {
+            log.info("지원되지 않는 JWT 토큰입니다.");
+        } catch (IllegalArgumentException e) {
+            log.info("JWT 토큰이 잘못되었습니다.");
+        }
+        return false;
+    }
+
+    private Claims parseClaims(String accessToken) {
+        try {
+            return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(accessToken).getBody();
+        } catch (ExpiredJwtException e) {
+            return e.getClaims();
+        }
+    }
+}

--- a/src/main/java/me/seowoo/market/repository/MemberRepository.java
+++ b/src/main/java/me/seowoo/market/repository/MemberRepository.java
@@ -1,0 +1,13 @@
+package me.seowoo.market.repository;
+
+import me.seowoo.market.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    Optional<Member> findByEmail(String email);
+
+    boolean existsByEmail(String email);
+}

--- a/src/main/java/me/seowoo/market/service/AuthService.java
+++ b/src/main/java/me/seowoo/market/service/AuthService.java
@@ -1,0 +1,51 @@
+package me.seowoo.market.service;
+
+import lombok.RequiredArgsConstructor;
+import me.seowoo.market.dto.MemberRequestDto;
+import me.seowoo.market.dto.MemberResponseDto;
+import me.seowoo.market.dto.TokenDto;
+import me.seowoo.market.entity.Member;
+import me.seowoo.market.jwt.TokenProvider;
+import me.seowoo.market.repository.MemberRepository;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final AuthenticationManagerBuilder authenticationManagerBuilder;
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final TokenProvider tokenProvider;
+
+    @Transactional
+    public MemberResponseDto signup(MemberRequestDto memberRequestDto) {
+        if (memberRepository.existsByEmail(memberRequestDto.getEmail())) {
+            throw new RuntimeException("이미 가입되어 있는 회원입니다.");
+        }
+
+        Member member = memberRequestDto.toMember(passwordEncoder);
+        return MemberResponseDto.of(memberRepository.save(member));
+    }
+
+    @Transactional
+    public TokenDto login(MemberRequestDto memberRequestDto) {
+        // 1. Login ID/PW를 기반으로 AuthenticationToken 생성
+        UsernamePasswordAuthenticationToken authenticationToken = memberRequestDto.toAuthentication();
+
+        // 2. 실제 검증(비밀번호 체크)이 이루어지는 부분
+        // authenticate 메서드가 실행될 때 CustomUserDetailsService에 만든 loadUserByUsername 메서드 실행
+        Authentication authentication = authenticationManagerBuilder.getObject().authenticate(authenticationToken);
+
+        // 3. 인증 정보를 기반으로 JWT 토큰 생성
+        TokenDto tokenDto = tokenProvider.generateTokenDto(authentication);
+
+        // 4. 토큰 발급
+        return tokenDto;
+    }
+}

--- a/src/main/java/me/seowoo/market/service/CustomUserDetailsService.java
+++ b/src/main/java/me/seowoo/market/service/CustomUserDetailsService.java
@@ -1,0 +1,41 @@
+package me.seowoo.market.service;
+
+import lombok.RequiredArgsConstructor;
+import me.seowoo.market.entity.Member;
+import me.seowoo.market.repository.MemberRepository;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    @Transactional
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        return memberRepository.findByEmail(username)
+                .map(this::createUserDetails)
+                .orElseThrow(() -> new UsernameNotFoundException(username + "-> 데이터베이스에서 찾을 수 없습니다."));
+    }
+
+    // DB에 User 값이 존재하면 UserDetails 객체로 만들어서 반환
+    private UserDetails createUserDetails(Member member) {
+        GrantedAuthority grantedAuthority = new SimpleGrantedAuthority(member.getAuthority().toString());
+
+        return new User(
+                String.valueOf(member.getId()),
+                member.getPassword(),
+                Collections.singleton(grantedAuthority)
+        );
+    }
+}

--- a/src/main/java/me/seowoo/market/service/MemberService.java
+++ b/src/main/java/me/seowoo/market/service/MemberService.java
@@ -1,0 +1,30 @@
+package me.seowoo.market.service;
+
+import lombok.RequiredArgsConstructor;
+import me.seowoo.market.dto.MemberResponseDto;
+import me.seowoo.market.repository.MemberRepository;
+import me.seowoo.market.util.SecurityUtil;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    @Transactional(readOnly = true)
+    public MemberResponseDto getMemberInfo(String email) {
+        return memberRepository.findByEmail(email)
+                .map(MemberResponseDto::of)
+                .orElseThrow(() -> new RuntimeException("존재하지 않는 회원입니다."));
+    }
+
+    // 현재 SecurityContext에 있는 회원 정보 가져오기
+    @Transactional(readOnly = true)
+    public MemberResponseDto getMyInfo() {
+        return memberRepository.findById(SecurityUtil.getCurrentMemberId())
+                .map(MemberResponseDto::of)
+                .orElseThrow(() -> new RuntimeException("로그인 회원 정보가 없습니다."));
+    }
+}

--- a/src/main/java/me/seowoo/market/util/SecurityUtil.java
+++ b/src/main/java/me/seowoo/market/util/SecurityUtil.java
@@ -1,0 +1,25 @@
+package me.seowoo.market.util;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+@Slf4j
+public class SecurityUtil {
+
+    private SecurityUtil() {
+
+    }
+
+    // SecurityContext에 회원 정보가 저장되는 시점
+    // Request가 들어올 때 JwtFilter의 doFilter에서 저장
+    public static Long getCurrentMemberId() {
+        final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication == null || authentication.getName() == null) {
+            throw new RuntimeException("Security Context에 인증 정보가 없습니다.");
+        }
+
+        return Long.parseLong(authentication.getName());
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,3 +4,8 @@ spring.datasource.password=1008
 
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
+
+# HS512 알고리즘을 사용하기 때문에 Secret Key는 64Byte 이상 사용
+# echo 'spring-boot-project-jwt-secret-leeseowoo-spring-boot-project-jwt-secret'|base64
+# 문자열을 Base64로 인코딩한 값
+jwt.secret=c3ByaW5nLWJvb3QtcHJvamVjdC1qd3Qtc2VjcmV0LWxlZXNlb3dvby1zcHJpbmctYm9vdC1wcm9qZWN0LWp3dC1zZWNyZXQK


### PR DESCRIPTION
## 작업 내용
- **Spring Security 및 JWT 적용**
- **회원가입 기능 개발**
  - 이메일 중복 검사 후 중복될 경우 예외 처리
  - 중복되지 않을 경우 PasswordEncoder를 통해 비밀번호를 암호화한 후 이메일과 비밀번호 저장
- **로그인 기능 개발**
  - 이메일/비밀번호 검증 후 인증 정보를 기반으로 생성한 Access Token 발급

## 세부 내용
- **Member 관련 클래스**
  - MemberController
  - MemberService
  - MemberRepository
  - Member
  - MemberRequestDto
  - MemberResponseDto

- **JWT 관련 클래스**
  - TokenProvider
    - JWT 암호화, 복호화, 검증 수행(회원 정보로 토큰을 생성하거나 토큰으로부터 회원 정보를 추출)
    - Constructor
      - application.properties에 설정한 jwt.secret 값으로 JWT 생성 시 사용하는 암호화 키 생성
    - generateTokenDto
      - 넘겨받은 회원 정보로 Access Token 생성
      - authentication.getName() 메서드가 username(member_id) 반환
    - getAuthentication
      - 토큰을 복호화하여 토큰에 있는 정보 추출
      - UserDetails 객체를 생성하여 UsernamePasswordAuthenticationToken 형태로 반환(SecurityContext를 사용하기 위한 절차)
    - validateToken
      - 토큰 정보 검증
      - Jwts 모듈이 예외 처리 수행
  - JwtFilter
    - API 요청 시 앞단에서 먼저 실행될 Custom Filter(OncePerRequestFilter 인터페이스를 구현했기 때문에 요청 시 한번만 실행)
    - doFilterInternal
      - Request Header에서 Access Token을 꺼내서 유효성 검사 후 정상 토큰일 경우 회원 정보를 꺼내서 SecurityContext에 저장
      - 요청이 정상적으로 Controller까지 도착했다면 SecurityContext에 member_id의 존재 보장
      - Access Token에 있는 member_id를 꺼내온 것이기 때문에 해당 회원이 탈퇴하여 member_id가 테이블에 없는 경우 등의 예외 상황 고려 필요

- **Spring Security 관련 클래스**
  - JwtSecurityConfig
    - 직접 작성한 JWT Filter를 Security Filter 앞에 추가
  - JwtAccessDeniedHandler
    - 회원 정보는 있지만 자원에 접근할 수 있는 권한이 없을 시 403 오류 응답
  - JwtAuthenticationEntryPoint
    - 회원 정보 없이 접근할 시 401 오류 응답
  - SecurityConfig
    - Spring Security 기본 설정
  - SecurityUtil
    - getCurrentMemberId
      - 내 정보(member_id)를 가져올 때 사용
      - API 요청 시 JwtFilter에서 AccessToken을 복호화하여 회원 정보를 SecurityContext에 저장, SecurityContext에 저장된 회원 정보는 전역에서 가져오기 가능
      - SecurityContext는 ThreadLocal에 회원 정보를 저장
      - member_id를 저장하게 했기 때문에 정보를 가져와서 Long 타입으로 파싱하여 반환

- **회원 인증 관련 클래스**
  - AuthController
    - 회원가입/로그인 요청 처리 API
    - SecurityConfig에서 /auth/** 요청은 permitAll 설정을 했기 때문에 토큰 검증 로직 미적용
  - AuthService
    - login
      - 입력한 이메일/비밀번호로 인증 정보 객체 UsernamePasswordAuthenticationToken 생성 후 AuthenticationManager의 authenticate 메서드의 매개변수로 전달하여 검증 후 Authentication 반환(내부 호출 과정을 거쳐 CustomUserDetailsService의 loadUserByUsername을 호출하고 결과를 반환하여 내부 검증 수행)
      - 인증이 완료된 authentication에는 member_id 포함
      - 인증 객체를 기반으로 Access Token을 생성하여 반환
  - CustomUserDetailsService
    - loadUserByUsername
      - 매개변수로 받은 이메일이 테이블에 존재할 경우 해당 회원 정보를 가져와서 UserDetails 객체를 생성하여 반환
      - 내부적으로 DaoAuthenticationProvider의 additionalAuthenticationChecks에서 실제 비밀번호 검증 수행, userDetails의 암호화된 비밀번호와 Request로 받아서 생성한 authentication을 비교
      - 입력한 비밀번호는 암호화되지 않은 값이고 테이블에 있는 비밀번호는 암호화된 값이지만 passwordEncoder를 통해 비교 가능

- **일반 API 요청**
  - API 요청 -> JWT Filter(Security Context 설정) -> Controller -> Service ...